### PR TITLE
Update SpriteSerializer.ts

### DIFF
--- a/src/app/modules/editor/scripts/export/SpriteSerializer.ts
+++ b/src/app/modules/editor/scripts/export/SpriteSerializer.ts
@@ -69,7 +69,7 @@ export function createSvgSprite(vectorLayer: VectorLayer, animation: Animation, 
   const totalWidth = width * numSteps + width;
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" ` +
-    `viewBox="0 0 ${totalWidth} ${height}" width="${totalWidth}px" height="${height}px">
+    `viewBox="0 0 ${totalWidth} ${height}" width="${totalWidth}" height="${height}">
 ${svgs.join('\n')}
 </svg>
 `;


### PR DESCRIPTION
`px `deleted on `width `and `height `values, because it was wrong – see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width