### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/app/modules/editor/scripts/common/ColorUtil.ts
+++ b/src/app/modules/editor/scripts/common/ColorUtil.ts
@@ -59,7 +59,7 @@ export function svgToAndroidColor(color: string): string | undefined {
   }
   const colorInstance = tinycolor(color);
   const colorHex = colorInstance.toHex();
-  const alphaHex = colorInstance.toHex8().substr(6);
+  const alphaHex = colorInstance.toHex8().slice(6);
   return '#' + (alphaHex !== 'ff' ? alphaHex : '') + colorHex;
 }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.